### PR TITLE
"Error: Cannot send non-string log to report portal!" is thrown in many cases

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -147,7 +147,7 @@ class API {
     async sendLog (projectName, options) {
         try {
             if(typeof options.message !== 'string')
-                throw new Error(`Cannot send non-string log to report portal!\n${options.message}`)
+                options.message = `${options.message}`;
             if (options.file) {
                 const MULTIPART_BOUNDARY = Math.floor(Math.random() * 10000000000).toString();
                 const fullPath = options.file.path;

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,9 @@ exports['default'] = () => {
         async reportLogs(testId, level, message, time, attachment) {
             if(message !== undefined) {
                 const isJSON = this.reporter.client.isJSON(message) || Array.isArray(message);
+                //If the log is a stacktrace, and we want to focus on printing the error message itself.
                 if(isJSON && JSON.parse(message).errMsg !== undefined) message = JSON.parse(message).errMsg;
+                //If the log is a JS Object
                 else if(isJSON) message = JSON.parse(message)
                 message = this.reporter.client.isJSON(message) ? JSON.stringify(message): message
             }


### PR DESCRIPTION
Fixed #24